### PR TITLE
feat(schema): allow to use "remove" mode

### DIFF
--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -72,6 +72,20 @@ describe("Schema", () => {
     expect(validate(t)).toEqual(true);
   });
 
+  it("Should remove extra properties", () => {
+    @Schema("remove")
+    class Test extends SchemaBase {
+      @String()
+      prop!: string;
+    }
+    const t = new Test({
+      prop!: "prop",
+      prop2: "prop2",
+    });
+    expect(validate(t)).toEqual(true);
+    expect(Object.keys(t)).toEqual(["prop"]);
+  });
+
   it("Should compile the schema before instantiation", () => {
     @Schema()
     class Test extends SchemaBase {

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import FastestValidator, { ValidationError } from "fastest-validator";
 
 export const SCHEMA_KEY = Symbol("propertyMetadata");
 export const COMPILE_KEY = Symbol("compileKey");
+type StrictMode = boolean | "remove";
 
 export const validate = (obj: { constructor: any }): true | ValidationError[] => {
   const validate = Reflect.getMetadata(COMPILE_KEY, obj.constructor);
@@ -30,7 +31,7 @@ const updateSchema = (target: any, key: string | symbol, options: any): void => 
   Reflect.defineMetadata(SCHEMA_KEY, s, target);
 };
 
-export function Schema (strict = false, messages = {}): any {
+export function Schema (strict: StrictMode = false, messages = {}): any {
   return function _Schema<T extends {new (...args: any[]): Record<string, unknown>}>(target: T): any  {
     updateSchema(target.prototype, "$$strict", strict);
     const s = Reflect.getMetadata(SCHEMA_KEY, target.prototype) || {};


### PR DESCRIPTION
Before this commit users were not able to use the "remove" mode on
schemas. This mode removes extra properties on validation.