### PR TITLE
fix: class instances constructor name loss

### DIFF
--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -100,6 +100,17 @@ describe("Schema", () => {
     expect(compiled).toBe(Reflect.getMetadata(COMPILE_KEY, t.constructor));
   });
 
+  it("should preserve the constructor name on instancies", () => {
+    @Schema()
+    class Test extends SchemaBase {
+      @String()
+      prop!: string;
+      prop2!: string;
+    }
+    const t = new Test({});
+    expect(t.constructor.name).toEqual("Test");
+  });
+
 });
 
 describe("Field", () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,17 +32,12 @@ const updateSchema = (target: any, key: string | symbol, options: any): void => 
 };
 
 export function Schema (strict: StrictMode = false, messages = {}): any {
-  return function _Schema<T extends {new (...args: any[]): Record<string, unknown>}>(target: T): any  {
+  return function _Schema<T extends {new (): any}>(target: T): T {
     updateSchema(target.prototype, "$$strict", strict);
     const s = Reflect.getMetadata(SCHEMA_KEY, target.prototype) || {};
     const v = new FastestValidator({ messages, useNewCustomCheckerFunction: true });
     Reflect.defineMetadata(COMPILE_KEY, v.compile(s), target);
-    return class extends target {
-      constructor (...args: any[]) {
-        super(...args);
-        return this;
-      }
-    };
+    return target;
   };
 }
 


### PR DESCRIPTION
Before this commit the Schema decoartor/annotation was returning a new
class which was leading to constructor name loss on class instances.
This commit simplifies the Schema decorator signature and return the
class the decorator is applied on. No returning anonymous class is less
error/divergence prone.

closes #9