### PR TITLE
fix(SchemaBase): allow to use class types in generics

### DIFF
--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -593,6 +593,17 @@ describe("SchemaBase", () => {
     expect(v.validate).toBeCalledWith(t);
   });
 
+  it("should allow using class type in generics", () => {
+    @Schema()
+    class Test extends SchemaBase {}
+    function create<T extends SchemaBase> (klass: { new (): T }): T {
+      return new klass();
+    }
+    const t = create(Test);
+    expect(t).toBeDefined();
+    expect(t).toBeInstanceOf(Test);
+  });
+
 });
 
 describe("Custom", () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -80,7 +80,9 @@ export function Nested (options: any | any[] = {}): any {
 }
 
 export class SchemaBase {
-  public constructor (obj: Record<string, unknown>) {
+  public constructor ();
+  public constructor (obj: Record<string, unknown>);
+  public constructor (obj?: Record<string, unknown>) {
     Object.assign(this, obj);
   }
 


### PR DESCRIPTION
Before this commit the SchemaBase class having only one constructor
signature requiring 1 argument it was not possible to use class types in
generics with classes extending SchemaBase. This commit fixes it.

closes #11