### PR TITLE
fix: child class decorators now correctly override parent field definitions

### DIFF
--- a/src/utils/get-schema.ts
+++ b/src/utils/get-schema.ts
@@ -6,6 +6,6 @@ import { getPrototypeChain } from "./get-prototype-chain.js";
 export function getSchema (klass: Class<any>): ValidationSchema {
   const chain = getPrototypeChain(klass.prototype);
   const schema = {};
-  Object.assign(schema, ...chain.map(c => Reflect.getOwnMetadata(SCHEMA_KEY, c)));
+  Object.assign(schema, ...chain.reverse().map(c => Reflect.getOwnMetadata(SCHEMA_KEY, c)));
   return schema;
 }

--- a/tests/validator.test.ts
+++ b/tests/validator.test.ts
@@ -757,6 +757,69 @@ describe("Extending schemas", () => {
     });
   });
 
+  test("Child can override parent field decorators", () => {
+    @Schema()
+    class Parent {
+      @String({ min: 5 })
+        name!: string;
+
+      @Number()
+        age!: number;
+    }
+
+    @Schema()
+    class Child extends Parent {
+      @String({ min: 1 })
+        name!: string;
+    }
+
+    expect(getSchema(Parent)).toEqual({
+      $$strict: false,
+      name: { type: "string", min: 5 },
+      age: { type: "number" },
+    });
+
+    expect(getSchema(Child)).toEqual({
+      $$strict: false,
+      name: { type: "string", min: 1 },
+      age: { type: "number" },
+    });
+
+    const child = new Child();
+    child.name = "ab";
+    child.age = 1;
+    expect(validate(child)).toEqual(true);
+
+    const parent = new Parent();
+    parent.name = "ab";
+    parent.age = 1;
+    expect((validate(parent) as ValidationError[])[0].type).toEqual("stringMin");
+  });
+
+  test("Grandchild can override through multiple levels", () => {
+    @Schema()
+    class A {
+      @String({ min: 10 })
+        field!: string;
+    }
+
+    @Schema()
+    class B extends A {
+      @String({ min: 5 })
+        field!: string;
+    }
+
+    @Schema()
+    class C extends B {
+      @String({ min: 1 })
+        field!: string;
+    }
+
+    expect(getSchema(A)).toEqual({ $$strict: false, field: { type: "string", min: 10 } });
+    expect(getSchema(B)).toEqual({ $$strict: false, field: { type: "string", min: 5 } });
+    expect(getSchema(C)).toEqual({ $$strict: false, field: { type: "string", min: 1 } });
+  });
+
   test("Validation is required for inherited properties", () => {
     @Schema()
     class Parent {


### PR DESCRIPTION
## Summary

- Reversed prototype chain merge order in `getSchema()` so child decorator metadata is applied after parent, allowing field overrides
- Added tests for single-level and multi-level inheritance override scenarios

Closes #50

## Root cause

`Object.assign` in `getSchema` spread prototypes child-first, so parent metadata silently overwrote child fields sharing the same key.

## Changes

- `src/utils/get-schema.ts`: `chain.reverse()` before mapping metadata
- `tests/validator.test.ts`: 2 new tests — "Child can override parent field decorators", "Grandchild can override through multiple levels"